### PR TITLE
Check minimum Node.js version in start scripts

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -12,6 +12,12 @@ if errorlevel 1 (
     exit /b
 )
 
+for /f "tokens=2 delims=v." %%i in ('node -v') do set "node_major=%%i"
+if %node_major% lss 22 (
+    echo Node 22 or newer is required. Detected %node_major%
+    exit /b
+)
+
 where /q bun
 if errorlevel 1 (
     npm i -g bun

--- a/start.sh
+++ b/start.sh
@@ -6,8 +6,14 @@ if ! command -v git 2>&1 >/dev/null; then
 fi
 
 if ! command -v node 2>&1 >/dev/null; then
-	echo You must install Node to proceed
-	exit 1
+        echo You must install Node to proceed
+        exit 1
+fi
+
+node_major=$(node --version | sed 's/^v//' | cut -d'.' -f1)
+if [ "$node_major" -lt 22 ]; then
+        echo Node 22 or newer is required. Detected $(node --version)
+        exit 1
 fi
 
 if ! command -v bun 2>&1 >/dev/null; then


### PR DESCRIPTION
- The start script now checks that the installed Node version is at least 22 before proceeding, showing the detected version if it’s too old

- The Windows batch file performs the same check using node -v, outputting an error message when the major version is below 22